### PR TITLE
fix datagram chunk creation

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -40,7 +40,7 @@ Transport.prototype.prepareDatagrams = function (chunks, cb) {
 
   const createDatagramArray = function (msgId) {
     for(var i = 0; i < chunks.length; i++) {
-      datagrams[i] = new Buffer(gelfBytes.concat(msgId, i, length, chunks[i]));
+      datagrams[i] = Buffer.concat([Buffer.from(gelfBytes), msgId, Buffer.from([i, length]), chunks[i]]);
     }
 
     cb && cb(null, datagrams);


### PR DESCRIPTION
The current implementation concatenates the bytes in a wrong way for message chunking. The provided implementation was testet against a real graylog installation.