### PR TITLE
ci: fix coverage collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10, 12, 14, 16]
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,24 +32,7 @@ jobs:
 
       - name: Run tests
         run: |
-          npm run test
-
-      - name: Coveralls Parallel
-        uses: coverallsapp/github-action@v1.1.2
-        with:
-          github-token: ${{ secrets.github_token }}
-          parallel: true
-          flag-name: run-${{ matrix.node-version }}-${{ matrix.os }}
-
-  coverage:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+          npm test
 
   automerge:
     needs: test

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![npm version](https://img.shields.io/npm/v/pino-gelf)](https://www.npmjs.com/package/pino-gelf)
 [![Build Status](https://img.shields.io/github/workflow/status/pinojs/pino-gelf/CI)](https://github.com/pinojs/pino-gelf/actions)
 [![Known Vulnerabilities](https://snyk.io/test/github/pinojs/pino-gelf/badge.svg)](https://snyk.io/test/github/pinojs/pino-gelf)
-[![Coverage Status](https://coveralls.io/repos/github/pinojs/pino-gelf/badge.svg?branch=master)](https://coveralls.io/github/pinojs/pino-gelf?branch=master)
 
 Pino GELF (pino-gelf) is a transport for the [Pino](https://www.npmjs.com/package/pino) logger. Pino GELF receives Pino logs from stdin and transforms them into [GELF](http://docs.graylog.org/en/2.1/pages/gelf.html) format before sending them to a remote [Graylog](https://www.graylog.org) server via UDP.
 


### PR DESCRIPTION
Stops failing CI workflows.
Tests in this repo do not generate coverage.