### PR TITLE
chore!: drop support for node 10 and 12; add support for node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [14, 16, 18]
         os: [macos-latest, ubuntu-latest]
     steps:
       - name: Check out repo


### PR DESCRIPTION
BREAKING CHANGE: Drops support for EOL node 10 and 12; adds support for node 18