### PR TITLE
Environment variables instead of CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,17 @@ node your-app.js | pino-gelf log -t
 
 __Note__: The defaults for these options are:
 
-Property|Default
----|---
-Host|`127.0.0.1`
-Port|`12201`
-Protocol|`udp`
-Maximum Chunk Size|`1420`
-Keep Alive|`true`
-Reconnection limit|`-1 (no limit)`
-Reconnection delay|`1000`
-Verbose Logging|`false`
-Passthrough|`false`
+Property|Environment Variable|Default
+---|---|---
+Host|`PINO_GELF_HOST`|`127.0.0.1`
+Port|`PINO_GELF_PORT`|`12201`
+Protocol|`PINO_GELF_PROTOCOL`|`udp`
+Maximum Chunk Size|`PINO_GELF_MAX_CHUNK_SIZE`|`1420`
+Keep Alive|`PINO_GELF_KEEP_ALIVE`|`true`
+Reconnection limit|`PINO_GELF_RECONNECTION_LIMIT`|`-1 (no limit)`
+Reconnection delay|`PINO_GELF_RECONNECTION_DELAY`|`1000`
+Verbose Logging|-|`false`
+Passthrough|-|`false`
 
 
 ## Example

--- a/index.js
+++ b/index.js
@@ -12,15 +12,15 @@ program
 program
   .command('log')
   .description('Run Pino-GELF')
-  .option('-h, --host [host]', 'Graylog Host')
-  .option('-p, --port [port]', 'Graylog Port', parseInt)
-  .option('-P, --protocol [protocol]', 'Graylog protocol (UDP, HTTP, HTTPS, TCP, TLS)')
-  .option('-m, --max-chunk-size [maxChunkSize]', 'Graylog UDP Input Maximum Chunk Size', parseInt)
-  .option('-k, --keep-alive [keepAlive]', 'HTTP/TCP keep alive')
-  .option('-r, --reconnection-limit [reconnectionLimit]', 'TCP reconnection limit', parseInt)
-  .option('-d, --reconnection-delay [reconnectionDelay]', 'TCP reconnection delay', parseInt)
-  .option('-v, --verbose', 'Output GELF to console')
-  .option('-t, --passthrough', 'Output original input to stdout to allow command chaining')
+  .addOption(new program.Option('-h, --host [host]', 'Graylog Host').env('PINO_GELF_HOST'))
+  .addOption(new program.Option('-p, --port [port]', 'Graylog Port').env('PINO_GELF_PORT').argParser(parseInt))
+  .addOption(new program.Option('-P, --protocol [protocol]', 'Graylog protocol (UDP, HTTP, HTTPS, TCP, TLS)').env('PINO_GELF_PROTOCOL'))
+  .addOption(new program.Option('-m, --max-chunk-size [maxChunkSize]', 'Graylog UDP Input Maximum Chunk Size').env('PINO_GELF_MAX_CHUNK_SIZE').argParser(parseInt))
+  .addOption(new program.Option('-k, --keep-alive [keepAlive]', 'HTTP/TCP keep alive').env('PINO_GELF_KEEP_ALIVE'))
+  .addOption(new program.Option('-r, --reconnection-limit [reconnectionLimit]', 'TCP reconnection limit').env('PINO_GELF_RECONNECTION_LIMIT').argParser(parseInt))
+  .addOption(new program.Option('-d, --reconnection-delay [reconnectionDelay]', 'TCP reconnection delay').env('PINO_GELF_RECONNECTION_DELAY').argParser(parseInt))
+  .addOption(new program.Option('-v, --verbose', 'Output GELF to console'))
+  .addOption(new program.Option('-t, --passthrough', 'Output original input to stdout to allow command chaining'))
   .action(function () {
     const options = this.opts();
 


### PR DESCRIPTION
Added the ability for options to take data from environment variables if the option is not specified in the CLI.

Example usage (docker compose):
```yml
service:
  my_app:
    image: myimage
    command: node main.js | npx pino-gelf log
    environment:
      PINO_GELF_HOST: log-server.host
      PINO_GELF_PROTOCOL: tcp
      PINO_GELF_RECONNECTION_DELAY: 2000
      PINO_GELF_KEEP_ALIVE: false
```


Property|Environment Variable|Default
---|---|---
Host|`PINO_GELF_HOST`|`127.0.0.1`
Port|`PINO_GELF_PORT`|`12201`
Protocol|`PINO_GELF_PROTOCOL`|`udp`
Maximum Chunk Size|`PINO_GELF_MAX_CHUNK_SIZE`|`1420`
Keep Alive|`PINO_GELF_KEEP_ALIVE` |`true`
Reconnection limit|`PINO_GELF_RECONNECTION_LIMIT`|`-1 (no limit)`
Reconnection delay|`PINO_GELF_RECONNECTION_DELAY`|`1000`
Verbose Logging|-|`false`
Passthrough|-|`false`