### PR TITLE
Fix ci.yml (and some improvements)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14, 16, 18, 20, "latest"] # add 22 when latest version becomes node-23
+        node-version: [14, 16, 18, 20, 22]
         os: [macos-latest, ubuntu-latest]
         exclude:
           - os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [14, 16, 18, 20, "latest"] # add 22 when latest version becomes node-23
         os: [macos-latest, ubuntu-latest]
         exclude:
           - os: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm i --ignore-scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       matrix:
         node-version: [14, 16, 18]
         os: [macos-latest, ubuntu-latest]
+        exclude:
+          - os: macos-latest
+            node-version: 14
     steps:
       - name: Check out repo
         uses: actions/checkout@v4


### PR DESCRIPTION
For the last 4 months, all attempts to run workflow have failed with an error: 
 ```
 Error: Unable to find Node version '14' for platform darwin and architecture arm64
 ```
 This PR fixes that.
 
 ---
 
 Changes:
 
- Exclusion `(macos-latest, node-14)` from the test job matrix (`Unable to find Node version '14'` error fix)
- Adding nodejs versions 20 and latest (currently 22) to the testing matrix
- Enabling caching for setup-alpine
 
