### PR TITLE
Fix test errors

### DIFF
--- a/lib/utils/schema/standard.js
+++ b/lib/utils/schema/standard.js
@@ -6,7 +6,7 @@ module.exports = {
     host: { type: 'string' },
     short_message: { type: 'string' },
     full_message: { type: 'string' },
-    timestamp: { type: 'integer' },
+    timestamp: { type: 'number' },
     level: { type: 'integer' }
   },
   patternProperties: {

--- a/test/pino-gelf.spec.js
+++ b/test/pino-gelf.spec.js
@@ -9,11 +9,11 @@ function pinoOutput(msg, level) {
 
 function testPinoToSyslogLevel(pinoLevel, syslogLevel, testCallback) {    
   const pg = cp.spawn('node', [pgPath, 'log', '-v']);
-  const expected = `{"_name":"app","version":"1.1","host":"box","short_message":"hello world","full_message":"hello world","timestamp":1531171074.631,"level":${syslogLevel}}\n`;
+  const expected = {"_name":"app","version":"1.1","host":"box","short_message":"hello world","full_message":"hello world","timestamp":1531171074.631,"level":syslogLevel};
 
   pg.stdout.on('data', data => {
     pg.kill();
-    expect(data.toString()).toEqual(expected);
+    expect(JSON.parse(data.toString())).toStrictEqual(expected);
     testCallback();
   });
     
@@ -120,10 +120,10 @@ describe('pinoGelf', function() {
 
   test('pino output is transformed to gelf output', done => {
     const pg = cp.spawn('node', [pgPath, 'log', '-v']);
-    const expected = '{"_name":"app","version":"1.1","host":"box","short_message":"hello world","full_message":"hello world","timestamp":1531171074.631,"level":6}\n';
+    const expected = {"_name":"app","version":"1.1","host":"box","short_message":"hello world","full_message":"hello world","timestamp":1531171074.631,"level":6};
         
     pg.stdout.on('data', data => {
-      expect(data.toString()).toEqual(expected);
+      expect(JSON.parse(data.toString())).toStrictEqual(expected);
       pg.kill();
       done();
     });
@@ -134,10 +134,10 @@ describe('pinoGelf', function() {
   test('short message is trimmed down', done => {
     const pg = cp.spawn('node', [pgPath, 'log', '-v']);
     const msg = 'hello world world world world world world world world world world world world';
-    const expected = `{"_name":"app","version":"1.1","host":"box","short_message":"hello world world world world world world world world world world","full_message":"${msg}","timestamp":1531171074.631,"level":6}\n`;
+    const expected = {"_name":"app","version":"1.1","host":"box","short_message":"hello world world world world world world world world world world","full_message":msg,"timestamp":1531171074.631,"level":6};
         
     pg.stdout.on('data', data => {
-      expect(data.toString()).toEqual(expected);
+      expect(JSON.parse(data.toString())).toStrictEqual(expected);
       pg.kill();
       done();
     });
@@ -168,11 +168,11 @@ describe('pinoGelf', function() {
   test('pino output with express-pino-middleware content is transformed to gelf output', done => {
     const pg = cp.spawn('node', [pgPath, 'log', '-v']);
     const pinoExpressOutput = '{"level":30,"time":1531171074631,"msg":"hello world","res":{"statusCode":304,"header":"HTTP/1.1 304 Not Modified"},"responseTime":8,"req":{"method":"GET","url":"/","headers":{"accept":"text/html"}},"pid":657,"hostname":"box","name":"app","v":1}';
-    const expected = '{"_res":"{\\"statusCode\\":304,\\"header\\":\\"HTTP/1.1 304 Not Modified\\"}","_responseTime":"8","_req":"{\\"method\\":\\"GET\\",\\"url\\":\\"/\\",\\"headers\\":{\\"accept\\":\\"text/html\\"}}","_name":"app","version":"1.1","host":"box","short_message":"hello world","full_message":"hello world","timestamp":1531171074.631,"level":6}\n';
+    const expected = {"_res":'{"statusCode":304,"header":"HTTP/1.1 304 Not Modified"}',"_responseTime":"8","_req":'{"method":"GET","url":"/","headers":{"accept":"text/html"}}',"_name":"app","version":"1.1","host":"box","short_message":"hello world","full_message":"hello world","timestamp":1531171074.631,"level":6};
         
     pg.stdout.on('data', data => {
       pg.kill();
-      expect(data.toString()).toEqual(expected);
+      expect(JSON.parse(data.toString())).toStrictEqual(expected);
       done();
     });
         
@@ -182,11 +182,11 @@ describe('pinoGelf', function() {
   test('pino output with custom fields is transformed to gelf output', done => {
     const pg = cp.spawn('node', [pgPath, 'log', '-v']);
     const pinoCustomOutput = '{"level":30,"time":1531171074631,"msg":"hello world","environment":"dev","colour":"red","pid":657,"hostname":"box","name":"app","v":1}';
-    const expected = '{"_environment":"dev","_colour":"red","_name":"app","version":"1.1","host":"box","short_message":"hello world","full_message":"hello world","timestamp":1531171074.631,"level":6}\n';
+    const expected = {"_environment":"dev","_colour":"red","_name":"app","version":"1.1","host":"box","short_message":"hello world","full_message":"hello world","timestamp":1531171074.631,"level":6};
         
     pg.stdout.on('data', data => {
       pg.kill();
-      expect(data.toString()).toEqual(expected);
+      expect(JSON.parse(data.toString())).toStrictEqual(expected);
       done();
     });
         


### PR DESCRIPTION
Adjusted gelf schema to allow timestamps with `.`
Made tests not fail on changed order of properties